### PR TITLE
🐛 FIX: Skip non-columns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,3 +129,4 @@ dmypy.json
 .pyre/
 
 .vscode/
+.idea/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,7 +30,7 @@ repos:
       additional_dependencies: [setuptools>=46.4.0]
 
   - repo: https://github.com/pycqa/isort
-    rev: 5.9.3
+    rev: 5.12.0
     hooks:
     - id: isort
 
@@ -41,7 +41,7 @@ repos:
       args: [--py37-plus]
 
   - repo: https://github.com/psf/black
-    rev: 21.7b0
+    rev: 23.7.0
     hooks:
     - id: black
 
@@ -57,7 +57,7 @@ repos:
       - flake8-markdown==0.2.0
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.910-1
+    rev: v1.4.1
     hooks:
     - id: mypy
       additional_dependencies:


### PR DESCRIPTION
Skip non-columns, for instance query expressions without a data type. See https://docs.sqlalchemy.org/en/14/orm/loading_columns.html#sqlalchemy.orm.query_expression.

These column expressions raise exceptions since they did not have the attributes one would expect from a normal column. They are (usually) dynamic, and not part of the table, thus should not be included in the document generation.