### PR TITLE
Unpin `sqlalchemy` dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ project_urls =
 packages = find:
 install_requires =
     sphinx>=3,<5
-    sqlalchemy~=1.4.22
+    sqlalchemy>=1.4.22
 python_requires = ~=3.7
 include_package_data = True
 


### PR DESCRIPTION
Allows it to be installed with `sqlalchemy` v2 and up