### PR TITLE
Unpin `sphinx` dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ project_urls =
 [options]
 packages = find:
 install_requires =
-    sphinx>=3,<5
+    sphinx>=3,<8
     sqlalchemy~=1.4.22
 python_requires = ~=3.7
 include_package_data = True


### PR DESCRIPTION
@chrisjsewell  Since the [test suite is quite minimal](https://github.com/chrisjsewell/sphinx-sqlalchemy/blob/d1e1238d5c845472ecaa3ecc6f8e64fed2129aea/tests/test_basic.py#L4) they will pass but won't provide much information. However, I built the AiiDA documentation locally with `Sphinx==7.2.6` without problems.