### PR TITLE
Update `.readthedocs.yml`

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,7 +1,11 @@
 version: 2
 
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.10"
+
 python:
-  version: "3.8"
   install:
       - method: pip
         path: .


### PR DESCRIPTION
Add the now required `build.os` key. Pin it to `ubuntu-22.04` and update to Python 3.10 since 3.8 is not avaible on that version of Ubuntu.