### PR TITLE
👌 Improve parsing of multiline docstrings

### DIFF
--- a/sphinx_sqlalchemy/main.py
+++ b/sphinx_sqlalchemy/main.py
@@ -1,6 +1,6 @@
 import importlib
 import logging
-import textwrap
+from sphinx.util.docstrings import prepare_docstring
 from typing import List, Optional, Set
 
 from docutils import nodes

--- a/sphinx_sqlalchemy/main.py
+++ b/sphinx_sqlalchemy/main.py
@@ -98,7 +98,9 @@ class SqlaModelDirective(SphinxDirective):
 
         # class documentation
         if mapper.class_.__doc__:
-            docstring_lines = prepare_docstring(mapper.class_.__doc__, self.state.document.settings.tab_width)
+            docstring_lines = prepare_docstring(
+                mapper.class_.__doc__, self.state.document.settings.tab_width
+            )
 
             self.state.nested_parse(
                 StringList(docstring_lines),

--- a/sphinx_sqlalchemy/main.py
+++ b/sphinx_sqlalchemy/main.py
@@ -1,6 +1,5 @@
 import importlib
 import logging
-from sphinx.util.docstrings import prepare_docstring
 from typing import List, Optional, Set
 
 from docutils import nodes
@@ -8,6 +7,7 @@ from docutils.statemachine import StringList
 
 # from docutils.parsers.rst import directives
 from sphinx.application import Sphinx
+from sphinx.util.docstrings import prepare_docstring
 from sphinx.util.docutils import SphinxDirective
 from sqlalchemy import Column, Constraint, inspect
 from sqlalchemy.orm.mapper import Mapper

--- a/sphinx_sqlalchemy/main.py
+++ b/sphinx_sqlalchemy/main.py
@@ -98,7 +98,6 @@ class SqlaModelDirective(SphinxDirective):
 
         # class documentation
         if mapper.class_.__doc__:
-
             # Extract docstring and dedent to support both D212 and D213 multiline docstrings
             docstring: str = mapper.class_.__doc__
             docstring_lines = docstring.splitlines(keepends=True)

--- a/sphinx_sqlalchemy/main.py
+++ b/sphinx_sqlalchemy/main.py
@@ -1,5 +1,6 @@
 import importlib
 import logging
+import textwrap
 from typing import List, Optional, Set
 
 from docutils import nodes
@@ -97,8 +98,14 @@ class SqlaModelDirective(SphinxDirective):
 
         # class documentation
         if mapper.class_.__doc__:
+
+            # Extract docstring and dedent to support both D212 and D213 multiline docstrings
+            docstring: str = mapper.class_.__doc__
+            docstring_lines = docstring.splitlines(keepends=True)
+            docstring_lines = [textwrap.dedent(line) for line in docstring_lines]
+
             self.state.nested_parse(
-                StringList(mapper.class_.__doc__.splitlines()),
+                StringList(docstring_lines),
                 self.content_offset,
                 definition,
             )

--- a/sphinx_sqlalchemy/main.py
+++ b/sphinx_sqlalchemy/main.py
@@ -98,10 +98,7 @@ class SqlaModelDirective(SphinxDirective):
 
         # class documentation
         if mapper.class_.__doc__:
-            # Extract docstring and dedent to support both D212 and D213 multiline docstrings
-            docstring: str = mapper.class_.__doc__
-            docstring_lines = docstring.splitlines(keepends=True)
-            docstring_lines = [textwrap.dedent(line) for line in docstring_lines]
+            docstring_lines = prepare_docstring(mapper.class_.__doc__, self.state.document.settings.tab_width)
 
             self.state.nested_parse(
                 StringList(docstring_lines),

--- a/tests/__snapshots__/test_docstrings.ambr
+++ b/tests/__snapshots__/test_docstrings.ambr
@@ -1,0 +1,161 @@
+# serializer version: 1
+# name: test_multiline_docstring_d212
+  '''
+  <document source="<src>/index.rst">
+      <definition_list classes="simple sqla">
+          <definition_list_item>
+              <term>
+                  module2.TestUserMultilineDocstringD212
+                   (
+                  <emphasis>
+                      dbusers_d212
+                  )
+              <definition>
+                  <paragraph>
+                      A
+                      <literal>
+                          user
+                      .
+                  <paragraph>
+                      The user has a multi-line doctsring.
+                  <paragraph>
+                      This is the last line of the docstring.
+                  <rubric>
+                      Columns:
+                  <table align="left" classes="colwidths-auto">
+                      <tgroup cols="3">
+                          <colspec>
+                          <colspec>
+                          <colspec>
+                          <tbody>
+                              <row>
+                                  <entry>
+                                      <paragraph>
+                                          <emphasis>
+                                              pk*
+                                  <entry>
+                                      <paragraph>
+                                          INTEGER
+                                  <entry>
+                                      <paragraph>
+                              <row>
+                                  <entry>
+                                      <paragraph>
+                                          first_name
+                                  <entry>
+                                      <paragraph>
+                                          VARCHAR?
+                                  <entry>
+                                      <paragraph>
+                                          The name of the user.
+                              <row>
+                                  <entry>
+                                      <paragraph>
+                                          last_name
+                                  <entry>
+                                      <paragraph>
+                                          VARCHAR(255)?
+                                  <entry>
+                                      <paragraph>
+                                          The surname of the user.
+                              <row>
+                                  <entry>
+                                      <paragraph>
+                                          dob
+                                  <entry>
+                                      <paragraph>
+                                          DATE
+                                  <entry>
+                                      <paragraph>
+                                          The date of birth.
+                  <rubric>
+                      Constraints:
+                  <bullet_list>
+                      <list_item>
+                          <paragraph>
+                              PRIMARY KEY (pk)
+                      <list_item>
+                          <paragraph>
+                              UNIQUE (first_name, last_name)
+  '''
+# ---
+# name: test_multiline_docstring_d213
+  '''
+  <document source="<src>/index.rst">
+      <definition_list classes="simple sqla">
+          <definition_list_item>
+              <term>
+                  module2.TestUserMultilineDocstringD213
+                   (
+                  <emphasis>
+                      dbusers_d213
+                  )
+              <definition>
+                  <paragraph>
+                      A
+                      <literal>
+                          user
+                      .
+                  <paragraph>
+                      The user has a multi-line doctsring.
+                  <paragraph>
+                      This is the last line of the docstring.
+                  <rubric>
+                      Columns:
+                  <table align="left" classes="colwidths-auto">
+                      <tgroup cols="3">
+                          <colspec>
+                          <colspec>
+                          <colspec>
+                          <tbody>
+                              <row>
+                                  <entry>
+                                      <paragraph>
+                                          <emphasis>
+                                              pk*
+                                  <entry>
+                                      <paragraph>
+                                          INTEGER
+                                  <entry>
+                                      <paragraph>
+                              <row>
+                                  <entry>
+                                      <paragraph>
+                                          first_name
+                                  <entry>
+                                      <paragraph>
+                                          VARCHAR?
+                                  <entry>
+                                      <paragraph>
+                                          The name of the user.
+                              <row>
+                                  <entry>
+                                      <paragraph>
+                                          last_name
+                                  <entry>
+                                      <paragraph>
+                                          VARCHAR(255)?
+                                  <entry>
+                                      <paragraph>
+                                          The surname of the user.
+                              <row>
+                                  <entry>
+                                      <paragraph>
+                                          dob
+                                  <entry>
+                                      <paragraph>
+                                          DATE
+                                  <entry>
+                                      <paragraph>
+                                          The date of birth.
+                  <rubric>
+                      Constraints:
+                  <bullet_list>
+                      <list_item>
+                          <paragraph>
+                              PRIMARY KEY (pk)
+                      <list_item>
+                          <paragraph>
+                              UNIQUE (first_name, last_name)
+  '''
+# ---

--- a/tests/__snapshots__/test_docstrings.ambr
+++ b/tests/__snapshots__/test_docstrings.ambr
@@ -19,7 +19,7 @@
                   <paragraph>
                       The user has a multi-line docstring:
                   <literal_block xml:space="preserve">
-                      This is an intented code block
+                      This is an indented code block
                   <paragraph>
                       This is the last line of the docstring.
                   <rubric>
@@ -101,7 +101,7 @@
                   <paragraph>
                       The user has a multi-line docstring:
                   <literal_block xml:space="preserve">
-                      This is an intented code block
+                      This is an indented code block
                   <paragraph>
                       This is the last line of the docstring.
                   <rubric>

--- a/tests/__snapshots__/test_docstrings.ambr
+++ b/tests/__snapshots__/test_docstrings.ambr
@@ -17,7 +17,7 @@
                           user
                       .
                   <paragraph>
-                      The user has a multi-line doctsring.
+                      The user has a multi-line docstring.
                   <paragraph>
                       This is the last line of the docstring.
                   <rubric>

--- a/tests/__snapshots__/test_docstrings.ambr
+++ b/tests/__snapshots__/test_docstrings.ambr
@@ -17,7 +17,9 @@
                           user
                       .
                   <paragraph>
-                      The user has a multi-line docstring.
+                      The user has a multi-line docstring:
+                  <literal_block xml:space="preserve">
+                      This is an intented code block
                   <paragraph>
                       This is the last line of the docstring.
                   <rubric>
@@ -97,7 +99,9 @@
                           user
                       .
                   <paragraph>
-                      The user has a multi-line docstring.
+                      The user has a multi-line docstring:
+                  <literal_block xml:space="preserve">
+                      This is an intented code block
                   <paragraph>
                       This is the last line of the docstring.
                   <rubric>

--- a/tests/__snapshots__/test_docstrings.ambr
+++ b/tests/__snapshots__/test_docstrings.ambr
@@ -97,7 +97,7 @@
                           user
                       .
                   <paragraph>
-                      The user has a multi-line doctsring.
+                      The user has a multi-line docstring.
                   <paragraph>
                       This is the last line of the docstring.
                   <rubric>

--- a/tests/modules/module2.py
+++ b/tests/modules/module2.py
@@ -7,7 +7,7 @@ class TestUserMultilineDocstringD212(Base):
     """
     A ``user``.
 
-    The user has a multi-line doctsring.
+    The user has a multi-line docstring.
 
     This is the last line of the docstring.
     """

--- a/tests/modules/module2.py
+++ b/tests/modules/module2.py
@@ -1,0 +1,36 @@
+from sqlalchemy import Column, UniqueConstraint, orm, types
+
+Base = orm.declarative_base()
+
+
+class TestUserMultilineDocstringD212(Base):
+    """
+    A ``user``.
+
+    The user has a multi-line doctsring.
+
+    This is the last line of the docstring.
+    """
+
+    __tablename__ = "dbusers_d212"
+    __table_args__ = (UniqueConstraint("first_name", "last_name"),)
+    pk = Column(types.Integer, primary_key=True)
+    first_name = Column(types.String, doc="The name of the user.")
+    last_name = Column(types.String(255), doc="The surname of the user.")
+    dob = Column(types.Date, nullable=False, doc="The date of birth.")
+
+
+class TestUserMultilineDocstringD213(Base):
+    """A ``user``.
+
+    The user has a multi-line doctsring.
+
+    This is the last line of the docstring.
+    """
+
+    __tablename__ = "dbusers_d213"
+    __table_args__ = (UniqueConstraint("first_name", "last_name"),)
+    pk = Column(types.Integer, primary_key=True)
+    first_name = Column(types.String, doc="The name of the user.")
+    last_name = Column(types.String(255), doc="The surname of the user.")
+    dob = Column(types.Date, nullable=False, doc="The date of birth.")

--- a/tests/modules/module2.py
+++ b/tests/modules/module2.py
@@ -9,7 +9,7 @@ class TestUserMultilineDocstringD212(Base):
 
     The user has a multi-line docstring::
 
-        This is an intented code block
+        This is an indented code block
 
     This is the last line of the docstring.
     """
@@ -27,7 +27,7 @@ class TestUserMultilineDocstringD213(Base):
 
     The user has a multi-line docstring::
 
-        This is an intented code block
+        This is an indented code block
 
     This is the last line of the docstring.
     """

--- a/tests/modules/module2.py
+++ b/tests/modules/module2.py
@@ -7,7 +7,9 @@ class TestUserMultilineDocstringD212(Base):
     """
     A ``user``.
 
-    The user has a multi-line docstring.
+    The user has a multi-line docstring::
+
+        This is an intented code block
 
     This is the last line of the docstring.
     """
@@ -23,7 +25,9 @@ class TestUserMultilineDocstringD212(Base):
 class TestUserMultilineDocstringD213(Base):
     """A ``user``.
 
-    The user has a multi-line docstring.
+    The user has a multi-line docstring::
+
+        This is an intented code block
 
     This is the last line of the docstring.
     """

--- a/tests/modules/module2.py
+++ b/tests/modules/module2.py
@@ -23,7 +23,7 @@ class TestUserMultilineDocstringD212(Base):
 class TestUserMultilineDocstringD213(Base):
     """A ``user``.
 
-    The user has a multi-line doctsring.
+    The user has a multi-line docstring.
 
     This is the last line of the docstring.
     """

--- a/tests/test_docstrings.py
+++ b/tests/test_docstrings.py
@@ -6,7 +6,7 @@ from sphinx_pytest.plugin import CreateDoctree
 
 
 def test_multiline_docstring_d212(sphinx_doctree_no_tr: CreateDoctree, snapshot):
-    """Basic test for molde with multiline string with D212 format"""
+    """Basic test for models with multiline string with D212 format"""
     sys.path.insert(0, os.path.join(os.path.dirname(__file__), "modules"))
     sphinx_doctree_no_tr.set_conf({"extensions": ["sphinx_sqlalchemy"]})
     result = sphinx_doctree_no_tr(".. sqla-model:: module2.TestUserMultilineDocstringD212")
@@ -14,7 +14,7 @@ def test_multiline_docstring_d212(sphinx_doctree_no_tr: CreateDoctree, snapshot)
     assert "\n".join([li.rstrip() for li in result.pformat().splitlines()]) == snapshot
 
 def test_multiline_docstring_d213(sphinx_doctree_no_tr: CreateDoctree, snapshot):
-    """Basic test for molde with multiline string with D213 format"""
+    """Basic test for models with multiline string with D213 format"""
     sys.path.insert(0, os.path.join(os.path.dirname(__file__), "modules"))
     sphinx_doctree_no_tr.set_conf({"extensions": ["sphinx_sqlalchemy"]})
     result = sphinx_doctree_no_tr(".. sqla-model:: module2.TestUserMultilineDocstringD213")

--- a/tests/test_docstrings.py
+++ b/tests/test_docstrings.py
@@ -1,0 +1,22 @@
+"""Basic tests"""
+import os.path
+import sys
+
+from sphinx_pytest.plugin import CreateDoctree
+
+
+def test_multiline_docstring_d212(sphinx_doctree_no_tr: CreateDoctree, snapshot):
+    """Basic test for molde with multiline string with D212 format"""
+    sys.path.insert(0, os.path.join(os.path.dirname(__file__), "modules"))
+    sphinx_doctree_no_tr.set_conf({"extensions": ["sphinx_sqlalchemy"]})
+    result = sphinx_doctree_no_tr(".. sqla-model:: module2.TestUserMultilineDocstringD212")
+    assert not result.warnings
+    assert "\n".join([li.rstrip() for li in result.pformat().splitlines()]) == snapshot
+
+def test_multiline_docstring_d213(sphinx_doctree_no_tr: CreateDoctree, snapshot):
+    """Basic test for molde with multiline string with D213 format"""
+    sys.path.insert(0, os.path.join(os.path.dirname(__file__), "modules"))
+    sphinx_doctree_no_tr.set_conf({"extensions": ["sphinx_sqlalchemy"]})
+    result = sphinx_doctree_no_tr(".. sqla-model:: module2.TestUserMultilineDocstringD213")
+    assert not result.warnings
+    assert "\n".join([li.rstrip() for li in result.pformat().splitlines()]) == snapshot

--- a/tests/test_docstrings.py
+++ b/tests/test_docstrings.py
@@ -9,14 +9,19 @@ def test_multiline_docstring_d212(sphinx_doctree_no_tr: CreateDoctree, snapshot)
     """Basic test for models with multiline docstring with D212 format"""
     sys.path.insert(0, os.path.join(os.path.dirname(__file__), "modules"))
     sphinx_doctree_no_tr.set_conf({"extensions": ["sphinx_sqlalchemy"]})
-    result = sphinx_doctree_no_tr(".. sqla-model:: module2.TestUserMultilineDocstringD212")
+    result = sphinx_doctree_no_tr(
+        ".. sqla-model:: module2.TestUserMultilineDocstringD212"
+    )
     assert not result.warnings
     assert "\n".join([li.rstrip() for li in result.pformat().splitlines()]) == snapshot
+
 
 def test_multiline_docstring_d213(sphinx_doctree_no_tr: CreateDoctree, snapshot):
     """Basic test for models with multiline docstring with D213 format"""
     sys.path.insert(0, os.path.join(os.path.dirname(__file__), "modules"))
     sphinx_doctree_no_tr.set_conf({"extensions": ["sphinx_sqlalchemy"]})
-    result = sphinx_doctree_no_tr(".. sqla-model:: module2.TestUserMultilineDocstringD213")
+    result = sphinx_doctree_no_tr(
+        ".. sqla-model:: module2.TestUserMultilineDocstringD213"
+    )
     assert not result.warnings
     assert "\n".join([li.rstrip() for li in result.pformat().splitlines()]) == snapshot

--- a/tests/test_docstrings.py
+++ b/tests/test_docstrings.py
@@ -6,7 +6,10 @@ from sphinx_pytest.plugin import CreateDoctree
 
 
 def test_multiline_docstring_d212(sphinx_doctree_no_tr: CreateDoctree, snapshot):
-    """Basic test for models with multiline docstring with D212 format"""
+    """Basic test for models with multiline docstring with D212 format
+    
+    see: https://docs.astral.sh/ruff/rules/multi-line-summary-first-line
+    """
     sys.path.insert(0, os.path.join(os.path.dirname(__file__), "modules"))
     sphinx_doctree_no_tr.set_conf({"extensions": ["sphinx_sqlalchemy"]})
     result = sphinx_doctree_no_tr(
@@ -17,7 +20,10 @@ def test_multiline_docstring_d212(sphinx_doctree_no_tr: CreateDoctree, snapshot)
 
 
 def test_multiline_docstring_d213(sphinx_doctree_no_tr: CreateDoctree, snapshot):
-    """Basic test for models with multiline docstring with D213 format"""
+    """Basic test for models with multiline docstring with D213 format
+    
+    see: https://docs.astral.sh/ruff/rules/multi-line-summary-second-line
+    """
     sys.path.insert(0, os.path.join(os.path.dirname(__file__), "modules"))
     sphinx_doctree_no_tr.set_conf({"extensions": ["sphinx_sqlalchemy"]})
     result = sphinx_doctree_no_tr(

--- a/tests/test_docstrings.py
+++ b/tests/test_docstrings.py
@@ -6,7 +6,7 @@ from sphinx_pytest.plugin import CreateDoctree
 
 
 def test_multiline_docstring_d212(sphinx_doctree_no_tr: CreateDoctree, snapshot):
-    """Basic test for models with multiline string with D212 format"""
+    """Basic test for models with multiline docstring with D212 format"""
     sys.path.insert(0, os.path.join(os.path.dirname(__file__), "modules"))
     sphinx_doctree_no_tr.set_conf({"extensions": ["sphinx_sqlalchemy"]})
     result = sphinx_doctree_no_tr(".. sqla-model:: module2.TestUserMultilineDocstringD212")
@@ -14,7 +14,7 @@ def test_multiline_docstring_d212(sphinx_doctree_no_tr: CreateDoctree, snapshot)
     assert "\n".join([li.rstrip() for li in result.pformat().splitlines()]) == snapshot
 
 def test_multiline_docstring_d213(sphinx_doctree_no_tr: CreateDoctree, snapshot):
-    """Basic test for models with multiline string with D213 format"""
+    """Basic test for models with multiline docstring with D213 format"""
     sys.path.insert(0, os.path.join(os.path.dirname(__file__), "modules"))
     sphinx_doctree_no_tr.set_conf({"extensions": ["sphinx_sqlalchemy"]})
     result = sphinx_doctree_no_tr(".. sqla-model:: module2.TestUserMultilineDocstringD213")

--- a/tests/test_docstrings.py
+++ b/tests/test_docstrings.py
@@ -7,7 +7,7 @@ from sphinx_pytest.plugin import CreateDoctree
 
 def test_multiline_docstring_d212(sphinx_doctree_no_tr: CreateDoctree, snapshot):
     """Basic test for models with multiline docstring with D212 format
-    
+
     see: https://docs.astral.sh/ruff/rules/multi-line-summary-first-line
     """
     sys.path.insert(0, os.path.join(os.path.dirname(__file__), "modules"))
@@ -21,7 +21,7 @@ def test_multiline_docstring_d212(sphinx_doctree_no_tr: CreateDoctree, snapshot)
 
 def test_multiline_docstring_d213(sphinx_doctree_no_tr: CreateDoctree, snapshot):
     """Basic test for models with multiline docstring with D213 format
-    
+
     see: https://docs.astral.sh/ruff/rules/multi-line-summary-second-line
     """
     sys.path.insert(0, os.path.join(os.path.dirname(__file__), "modules"))


### PR DESCRIPTION
# Description

Added support for multiline docstring. Current implementation was rendering multiline docstrings as indented notes. Current implementation supports both D212 and D213.

This is an answer to issue https://github.com/chrisjsewell/sphinx-sqlalchemy/issues/14

# Content

- Updated docstring processing in `main.py` file
- Added two new unit tests with D212 and D213 multiline docstring (and associated snapshots)