### PR TITLE
🐛 FIX: Exception when rendering `CheckConstraints`

### DIFF
--- a/sphinx_sqlalchemy/main.py
+++ b/sphinx_sqlalchemy/main.py
@@ -9,8 +9,9 @@ from docutils.statemachine import StringList
 from sphinx.application import Sphinx
 from sphinx.util.docstrings import prepare_docstring
 from sphinx.util.docutils import SphinxDirective
-from sqlalchemy import Column, ColumnElement, Constraint, inspect
+from sqlalchemy import Column, Constraint, inspect
 from sqlalchemy.orm.mapper import Mapper
+from sqlalchemy.sql.elements import ClauseElement
 from sqlalchemy.sql.schema import (
     CheckConstraint,
     ForeignKeyConstraint,
@@ -170,10 +171,10 @@ class SqlaModelDirective(SphinxDirective):
 
 
 def check_constraint_to_str(constraint: CheckConstraint) -> str:
-    if isinstance(constraint.sqltext, ColumnElement):
+    if isinstance(constraint.sqltext, ClauseElement):
         text = constraint.sqltext.compile(compile_kwargs={"literal_binds": True})
     else:
-        text = constraint.sqltext.text
+        text = getattr(constraint.sqltext, "text", "")
     return f"CHECK ({text})"
 
 

--- a/tests/__snapshots__/test_basic.ambr
+++ b/tests/__snapshots__/test_basic.ambr
@@ -69,6 +69,9 @@
                   <bullet_list>
                       <list_item>
                           <paragraph>
+                              CHECK (length(trim('first_name')) > 0)
+                      <list_item>
+                          <paragraph>
                               PRIMARY KEY (pk)
                       <list_item>
                           <paragraph>

--- a/tests/modules/module1.py
+++ b/tests/modules/module1.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, UniqueConstraint, orm, types
+from sqlalchemy import CheckConstraint, Column, UniqueConstraint, func, orm, types
 
 Base = orm.declarative_base()
 
@@ -7,7 +7,12 @@ class TestUser(Base):
     """A ``user``."""
 
     __tablename__ = "dbusers"
-    __table_args__ = (UniqueConstraint("first_name", "last_name"),)
+    __table_args__ = (
+        UniqueConstraint("first_name", "last_name"),
+        CheckConstraint(
+            func.length(func.trim("first_name")) > 0, "check_project_has_name"
+        ),
+    )
     pk = Column(types.Integer, primary_key=True)
     first_name = Column(types.String, doc="The name of the user.")
     last_name = Column(types.String(255), doc="The surname of the user.")


### PR DESCRIPTION
To get support from mypy and other tools, it is helpful to express CheckConstraints not as text but as expressions with direct reference to the column objects. This is currently not possible.

```python
from sqlalchemy import CheckConstraint
from sqlalchemy.orm import Mapped, mapped_column
from sqlalchemy.sql import func


class Project(Schema):
    __tablename__ = "projects"

    number: Mapped[int] = mapped_column(primary_key=True)
    name: Mapped[str] = mapped_column()

    __table_args__ = (
        CheckConstraint(func.length(func.trim(name)) > 0, "check_project_has_name"),
    )
```

Building the docs for this model causes the following exception:

```
AttributeError: Neither 'BinaryExpression' object nor 'Comparator' object has an attribute 'text'
```

This small adjustment makes it work.